### PR TITLE
modify data type of list

### DIFF
--- a/src/main/clojure/clojure/data/generators.clj
+++ b/src/main/clojure/clojure/data/generators.clj
@@ -139,7 +139,7 @@ instance you can get a repeatable basis for tests."
   "Create a list with elements from f and sized from sizer."
   ([f] (list f default-sizer))
   ([f sizer]
-     (reps sizer f)))
+     (apply core/list (reps sizer f))))
 
 (defmacro primitive-array
   [type]


### PR DESCRIPTION
'list' is not return list.

```clojure
user=> (require '[clojure.data.generators :as gen])
nil
user=> (list? (gen/list gen/anything))
false
```