### PR TITLE
docs: make consistent with latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ This project follows the version scheme MAJOR.MINOR.PATCH where each component p
 
 [Leiningen](https://github.com/technomancy/leiningen) dependency information:
 
-    [org.clojure/data.generators "1.1.0"]
+    [org.clojure/data.generators "1.0.0"]
 
 [Maven](http://maven.apache.org/) dependency information:
 
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>data.generators</artifactId>
-      <version>1.1.0</version>
+      <version>1.0.0</version>
     </dependency>
 
 Developer Information


### PR DESCRIPTION
So people following the readme will grab dependency properly.